### PR TITLE
Push cert env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "npm run clean && babel -d ./dist ./src -s",
     "postinstall": "npm run build",
     "start": "node ./dist/index.js",
-    "heroku-prebuild": "echo $IOS_PFX_CERTIFICATE_BASE_64 | base64 --decode > key.p12",
+    "heroku-prebuild": "echo $IOS_PFX_CERTIFICATE_BASE_64 | base64 --decode > $IOS_PFX_CERTIFICATE",
     "dev:watch": "nodemon --watch 'src/**/*' -e js,json --exec 'npm run dev:src'",
     "dev:src": "babel-node src",
     "dev:dist": "npm run build && nodemon ./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "build": "npm run clean && babel -d ./dist ./src -s",
     "postinstall": "npm run build",
     "start": "node ./dist/index.js",
+    "heroku-prebuild": "echo $IOS_PFX_CERTIFICATE_BASE_64 | base64 --decode > key.p12",
+    "dev:watch": "nodemon --watch 'src/**/*' -e js,json --exec 'npm run dev:src'",
     "dev:src": "babel-node src",
     "dev:dist": "npm run build && nodemon ./dist/index.js",
     "pretest": "MONGODB_VERSION=4.2.3 mongodb-runner start",

--- a/src/api.js
+++ b/src/api.js
@@ -13,8 +13,9 @@ const {
   SERVER_URL,
   REST_API_KEY,
   PARSE_SERVER_LOG_LEVEL,
+  IOS_PFX_CERTIFICATE,
+  IOS_PASSPHRASE
 } = process.env;
-
 
 // Build parse server instance
 const api = new ParseServer({
@@ -28,8 +29,8 @@ const api = new ParseServer({
   logLevel: PARSE_SERVER_LOG_LEVEL || 'info',
   push: {
     ios: {
-      pfx: 'Benji Signing Certificate.p12',
-      passphrase: '', // optional password to your p12/PFX
+      pfx: IOS_PFX_CERTIFICATE,
+      passphrase: IOS_PASSPHRASE,
       topic: 'com.Benji.Benji',
       production: true,
     },


### PR DESCRIPTION
Certificates are now env vars. 
For heroku build process we need to create an env var called IOS_PFX_CERTIFICATE_BASE_64 and other one called $IOS_PFX_CERTIFICATE. Heroku prebuild command will convert base64 to file. And this file will be used as pfx certificate. 
