### PR TITLE
Remove reinitialization

### DIFF
--- a/src/providers/ParseProvider.js
+++ b/src/providers/ParseProvider.js
@@ -1,8 +1,3 @@
-import Parse from 'parse/node';
-
-const { APP_ID, JAVASCRIPT_KEY, MASTER_KEY, SERVER_URL } = process.env;
-
-Parse.initialize(APP_ID, JAVASCRIPT_KEY, MASTER_KEY);
-Parse.serverURL = SERVER_URL;
+const Parse = global.Parse;
 
 export default Parse;


### PR DESCRIPTION
Parse has its own client instance set as a global javascript variable. So there is no need to reinitialize again.

I suggest reviewing this change.