### PR TITLE
Add sendMessage cloud function

### DIFF
--- a/src/cloud/index.js
+++ b/src/cloud/index.js
@@ -15,6 +15,7 @@ import connectionAfterSave from './webhooks/connectionAfterSave';
 import userBeforeSave from './webhooks/userBeforeSave';
 import userAfterSave from './webhooks/userAfterSave';
 import userAfterDelete from './webhooks/userAfterDelete';
+import sendMessage from './sendMessage';
 
 // Load Environment variables
 const { BENJI_SECRET_PASSWORD_TOKEN } = process.env;
@@ -33,6 +34,8 @@ Parse.Cloud.define('getChatToken', getChatToken);
 Parse.Cloud.define('getConnections', getConnections);
 Parse.Cloud.define('updateConnection', updateConnection);
 Parse.Cloud.define('createChannel', createChannel);
+
+Parse.Cloud.define('sendMessage', sendMessage);
 
 // --- Cloud code webhooks ----------------------------------------------------
 // Connection webhooks

--- a/src/cloud/sendMessage.js
+++ b/src/cloud/sendMessage.js
@@ -1,0 +1,16 @@
+import MessagingService from '../services/MessagingService';
+
+/**
+ * Send an SMS message
+ * @param {Object} request
+ */
+const sendMessage = async request => {
+  const { params, master } = request;
+  if (!master) throw new Error('You are not allowed to run this function');
+
+  const { phoneNumber, message } = params;
+
+  return MessagingService.createMessage(phoneNumber, message);
+};
+
+export default sendMessage;

--- a/src/services/MessagingService.js
+++ b/src/services/MessagingService.js
@@ -1,0 +1,37 @@
+import ExtendableError from 'extendable-error-class';
+import Twilio from '../providers/TwilioProvider';
+
+export class MessagingServiceError extends ExtendableError {}
+
+/**
+ * Create an SMS message
+
+ * @param {String} phoneNumber
+ * @param {String} message
+ * @returns {Promise}
+ */
+const createMessage = async (phoneNumber, message) => {
+  if (!phoneNumber) {
+    throw new MessagingServiceError('[SmQNWk96] phoneNumber is required');
+  }
+
+  if (!message || typeof message !== 'string') {
+    throw new MessagingServiceError('[ITLA8RgD] message is required');
+  }
+
+  try {
+    const messageResult = await new Twilio().client.messages.create({
+      from: '+12012560616',
+      to: phoneNumber,
+      body: message,
+    });
+    const { sid, status, errorCode, errorMessage } = messageResult;
+    return { sid, status, errorCode, errorMessage };
+  } catch (error) {
+    throw new MessagingServiceError(error.message);
+  }
+};
+
+export default {
+  createMessage,
+};


### PR DESCRIPTION
This PR adds a cloud function to send SMS to a given phone number. It's only runnable by master key authorized request. This means that it only be called by a client with a master key set.
In our case, it will be available for cloud code and website API.

Let me know if it works for you.

This PR fix #137 